### PR TITLE
add end date of 9-30 to range

### DIFF
--- a/index.html
+++ b/index.html
@@ -1372,20 +1372,22 @@ function onEachFeatureLocationPts(feature, layer) {
 	 	}
 	
 	//Sets the dropdowns and ranges for the date range picker
+	// console.log("Current Avi Year: ", currentAviYear);
+
 	$('#reportrange').daterangepicker({
 		"showDropdowns": false,
-		// October 1, currentAviYear
+		// October 1 thru Sept 30, currentAviYear
 		"startDate": moment(currentAviYear + '-10-01').subtract(5, 'years'),
-		"endDate": moment(),
+		"endDate": moment((currentAviYear + 1) + '-9-30'),
 		locale: {
       		format: 'MM/DD/YYYY'
    		 },
 		ranges: {
-				'Last 5 Avalanche Years': [moment(currentAviYear + '-10-01').subtract(5, 'years'), now],
-				'Current Avalanche Year': [moment(currentAviYear + '-10-01').subtract(1, 'years'), now],
-				'Last Avalanche Year': [moment(currentAviYear + '-10-01').subtract(2, 'years'), moment(currentAviYear + '-09-30').subtract(1, 'years')],
-				'Last 10 Avalanche Years': [moment(currentAviYear + '-10-01').subtract(10, 'years'), now],
-				'All': [moment('2008-01-01'), now],
+				'Last 5 Avalanche Years': [moment(currentAviYear + '-10-01').subtract(5, 'years'), moment((currentAviYear + 1) + '-9-30')],
+				'Current Avalanche Year': [moment(currentAviYear + '-10-01'), moment((currentAviYear + 1) + '-9-30')],
+				'Last Avalanche Year': [moment(currentAviYear + '-10-01').subtract(1, 'years'), moment(currentAviYear + '-09-30')],
+				'Last 10 Avalanche Years': [moment(currentAviYear + '-10-01').subtract(10, 'years'), moment((currentAviYear + 1) + '-9-30')],
+				'All': [moment('2008-01-01'), moment((currentAviYear + 1) + '-9-30')],
 				},
 				//maxDate: moment()
 		}, 


### PR DESCRIPTION
instead of ending on today, the current avi year will show the end date that is in the future on 9-30 as the last day of the avi year.